### PR TITLE
Add WPF app for WhisperX transcription and Ollama summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,52 @@
+# WhisperX Ollama Meeting Summarizer
+
+This repository now includes a Windows Presentation Foundation (WPF) application that orchestrates local [WhisperX](https://github.com/m-bain/whisperx) transcriptions with speaker diarization and summarises the results using your locally installed [Ollama](https://ollama.com/) models.
+
+## Features
+
+- Select any meeting audio file and run WhisperX with diarization to obtain a detailed transcript.
+- Automatically chunk long transcripts so that the Ollama model receives manageable input sizes.
+- Choose which Ollama model to run by querying the locally installed models list.
+- Edit the summarisation prompt directly in the UI, save prompt presets, and re-use them later.
+- Display diarised transcript chunks with timestamps and speaker labels alongside the generated summary.
+
+## Project layout
+
+```
+WhisperXOllamaApp.sln        # Visual Studio solution
+src/
+  WhisperXOllamaApp/         # WPF application source
+```
+
+## Building
+
+The project targets **.NET 8.0** with WPF (`net8.0-windows10.0.19041.0`). Open the solution in Visual Studio 2022 (17.8 or later) on Windows with the `.NET Desktop Development` workload installed, then build and run the application.
+
+If you prefer the CLI:
+
+```powershell
+dotnet build WhisperXOllamaApp.sln
+dotnet run --project src/WhisperXOllamaApp/WhisperXOllamaApp.csproj
+```
+
+> **Note:** the container used to author this change does not have the .NET SDK installed, so builds were not executed here.
+
+## Runtime dependencies
+
+- **WhisperX** must be installed and available on the system `PATH` (or adjust the executable path inside `WhisperXOptions`). The app launches WhisperX with `--diarize` and `--output_format json` to capture diarised transcripts.
+- **Ollama** must be installed locally and the CLI must be reachable via `ollama` on the `PATH`. The app uses `ollama list --json` to discover models and pipes prompts into `ollama run <model>` for each transcript chunk.
+
+Ensure both tools are installed and functioning from a regular terminal before using the GUI.
+
+## Prompt placeholders
+
+The default prompt – and any presets you save – can use the following placeholders:
+
+- `{{chunk}}` – the diarised transcript chunk that will be summarised.
+- `{{previous_summary}}` – the cumulative summary generated from prior chunks (or `(none)` for the first chunk).
+
+These placeholders are replaced automatically before sending the prompt to Ollama, enabling iterative summarisation of long meetings without overwhelming the model.
+
+## Preset storage
+
+Prompt presets are stored as JSON under `%APPDATA%\WhisperXOllamaApp\prompt-presets.json`. You can manually back up or edit this file if required.

--- a/WhisperXOllamaApp.sln
+++ b/WhisperXOllamaApp.sln
@@ -1,0 +1,21 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34309.116
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WhisperXOllamaApp", "src/WhisperXOllamaApp/WhisperXOllamaApp.csproj", "{9E0F13A4-18C4-4B76-8A4A-109AC8809EA7}"
+EndProject
+Global
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{9E0F13A4-18C4-4B76-8A4A-109AC8809EA7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{9E0F13A4-18C4-4B76-8A4A-109AC8809EA7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{9E0F13A4-18C4-4B76-8A4A-109AC8809EA7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{9E0F13A4-18C4-4B76-8A4A-109AC8809EA7}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
+GlobalSection(SolutionProperties) = preSolution
+HideSolutionNode = FALSE
+EndGlobalSection
+EndGlobal

--- a/src/WhisperXOllamaApp/App.xaml
+++ b/src/WhisperXOllamaApp/App.xaml
@@ -1,0 +1,12 @@
+<Application x:Class="WhisperXOllamaApp.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="Views/MainWindow.xaml">
+    <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="Resources/Styles.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Application.Resources>
+</Application>

--- a/src/WhisperXOllamaApp/App.xaml.cs
+++ b/src/WhisperXOllamaApp/App.xaml.cs
@@ -1,0 +1,7 @@
+using System.Windows;
+
+namespace WhisperXOllamaApp;
+
+public partial class App : Application
+{
+}

--- a/src/WhisperXOllamaApp/Models/PromptPreset.cs
+++ b/src/WhisperXOllamaApp/Models/PromptPreset.cs
@@ -1,0 +1,9 @@
+namespace WhisperXOllamaApp.Models;
+
+public class PromptPreset
+{
+    public string Name { get; set; } = string.Empty;
+    public string Prompt { get; set; } = string.Empty;
+
+    public override string ToString() => Name;
+}

--- a/src/WhisperXOllamaApp/Models/TranscriptChunk.cs
+++ b/src/WhisperXOllamaApp/Models/TranscriptChunk.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace WhisperXOllamaApp.Models;
+
+public class TranscriptChunk
+{
+    public string Header { get; set; } = string.Empty;
+    public string Content { get; set; } = string.Empty;
+    public TimeSpan Start { get; set; }
+    public TimeSpan End { get; set; }
+}

--- a/src/WhisperXOllamaApp/Models/TranscriptionSegment.cs
+++ b/src/WhisperXOllamaApp/Models/TranscriptionSegment.cs
@@ -1,0 +1,7 @@
+namespace WhisperXOllamaApp.Models;
+
+public record TranscriptionSegment(
+    string Speaker,
+    double Start,
+    double End,
+    string Text);

--- a/src/WhisperXOllamaApp/Models/WhisperXResult.cs
+++ b/src/WhisperXOllamaApp/Models/WhisperXResult.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace WhisperXOllamaApp.Models;
+
+public class WhisperXResult
+{
+    public IReadOnlyList<TranscriptionSegment> Segments { get; }
+
+    public WhisperXResult(IReadOnlyList<TranscriptionSegment> segments)
+    {
+        Segments = segments;
+    }
+}

--- a/src/WhisperXOllamaApp/Resources/Styles.xaml
+++ b/src/WhisperXOllamaApp/Resources/Styles.xaml
@@ -1,0 +1,4 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+</ResourceDictionary>

--- a/src/WhisperXOllamaApp/Services/OllamaOptions.cs
+++ b/src/WhisperXOllamaApp/Services/OllamaOptions.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace WhisperXOllamaApp.Services;
+
+public class OllamaOptions
+{
+    public string ExecutablePath { get; set; } = "ollama";
+    public TimeSpan CommandTimeout { get; set; } = TimeSpan.FromMinutes(10);
+}

--- a/src/WhisperXOllamaApp/Services/OllamaService.cs
+++ b/src/WhisperXOllamaApp/Services/OllamaService.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace WhisperXOllamaApp.Services;
+
+public class OllamaService
+{
+    private readonly OllamaOptions _options;
+
+    public OllamaService()
+        : this(new OllamaOptions())
+    {
+    }
+
+    public OllamaService(OllamaOptions options)
+    {
+        _options = options;
+    }
+
+    public async Task<IReadOnlyList<string>> ListModelsAsync(CancellationToken cancellationToken)
+    {
+        var psi = CreateProcessStartInfo();
+        psi.ArgumentList.Add("list");
+        psi.ArgumentList.Add("--json");
+
+        using var process = Process.Start(psi) ?? throw new InvalidOperationException("Failed to start ollama process");
+
+        var stdoutTask = process.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
+
+        await WaitForExitAsync(process, cancellationToken).ConfigureAwait(false);
+
+        var stdout = await stdoutTask.ConfigureAwait(false);
+        var stderr = await stderrTask.ConfigureAwait(false);
+
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException($"Ollama list failed with code {process.ExitCode}: {stderr}");
+        }
+
+        var models = new List<string>();
+        using var reader = new StringReader(stdout);
+        string? line;
+        while ((line = await reader.ReadLineAsync()) is not null)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            using var document = JsonDocument.Parse(line);
+            if (document.RootElement.TryGetProperty("name", out var nameElement))
+            {
+                var name = nameElement.GetString();
+                if (!string.IsNullOrWhiteSpace(name))
+                {
+                    models.Add(name);
+                }
+            }
+        }
+
+        return models;
+    }
+
+    public async Task<string> GenerateResponseAsync(string model, string prompt, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(model))
+        {
+            throw new ArgumentException("Model cannot be empty", nameof(model));
+        }
+
+        var psi = CreateProcessStartInfo();
+        psi.ArgumentList.Add("run");
+        psi.ArgumentList.Add(model);
+
+        using var process = Process.Start(psi) ?? throw new InvalidOperationException("Failed to start ollama process");
+
+        await process.StandardInput.WriteAsync(prompt);
+        await process.StandardInput.FlushAsync();
+        process.StandardInput.Close();
+
+        var outputBuilder = new StringBuilder();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(_options.CommandTimeout);
+
+        while (await process.StandardOutput.ReadLineAsync() is { } line)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            try
+            {
+                using var document = JsonDocument.Parse(line);
+                if (document.RootElement.TryGetProperty("response", out var responseElement))
+                {
+                    outputBuilder.Append(responseElement.GetString());
+                }
+            }
+            catch (JsonException)
+            {
+                outputBuilder.AppendLine(line);
+            }
+        }
+
+        var stderr = await process.StandardError.ReadToEndAsync().ConfigureAwait(false);
+        await WaitForExitAsync(process, cts.Token).ConfigureAwait(false);
+
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException($"Ollama run failed with code {process.ExitCode}: {stderr}");
+        }
+
+        return outputBuilder.ToString();
+    }
+
+    private ProcessStartInfo CreateProcessStartInfo()
+    {
+        return new ProcessStartInfo
+        {
+            FileName = _options.ExecutablePath,
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+    }
+
+    private static async Task WaitForExitAsync(Process process, CancellationToken cancellationToken)
+    {
+        await Task.Run(() => process.WaitForExit(), cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/WhisperXOllamaApp/Services/PromptPresetStorage.cs
+++ b/src/WhisperXOllamaApp/Services/PromptPresetStorage.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+using WhisperXOllamaApp.Models;
+
+namespace WhisperXOllamaApp.Services;
+
+public class PromptPresetStorage
+{
+    private readonly string _filePath;
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    public PromptPresetStorage()
+        : this(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "WhisperXOllamaApp", "prompt-presets.json"))
+    {
+    }
+
+    public PromptPresetStorage(string filePath)
+    {
+        _filePath = filePath;
+    }
+
+    public async Task<IReadOnlyList<PromptPreset>> LoadAsync()
+    {
+        if (!File.Exists(_filePath))
+        {
+            return Array.Empty<PromptPreset>();
+        }
+
+        await using var stream = File.OpenRead(_filePath);
+        var presets = await JsonSerializer.DeserializeAsync<List<PromptPreset>>(stream, SerializerOptions).ConfigureAwait(false);
+        return presets ?? new List<PromptPreset>();
+    }
+
+    public async Task SaveAsync(IEnumerable<PromptPreset> presets)
+    {
+        var directory = Path.GetDirectoryName(_filePath);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        await using var stream = File.Create(_filePath);
+        await JsonSerializer.SerializeAsync(stream, presets, SerializerOptions).ConfigureAwait(false);
+    }
+}

--- a/src/WhisperXOllamaApp/Services/WhisperXOptions.cs
+++ b/src/WhisperXOllamaApp/Services/WhisperXOptions.cs
@@ -1,0 +1,11 @@
+namespace WhisperXOllamaApp.Services;
+
+public class WhisperXOptions
+{
+    public string ExecutablePath { get; set; } = "whisperx";
+    public string Model { get; set; } = "large-v2";
+    public string? Language { get; set; }
+    public string ComputeType { get; set; } = "auto";
+    public bool EnableDiarization { get; set; } = true;
+    public string? OutputDirectory { get; set; }
+}

--- a/src/WhisperXOllamaApp/Services/WhisperXService.cs
+++ b/src/WhisperXOllamaApp/Services/WhisperXService.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using WhisperXOllamaApp.Models;
+
+namespace WhisperXOllamaApp.Services;
+
+public class WhisperXService
+{
+    private readonly WhisperXOptions _options;
+
+    public WhisperXService()
+        : this(new WhisperXOptions())
+    {
+    }
+
+    public WhisperXService(WhisperXOptions options)
+    {
+        _options = options;
+    }
+
+    public async Task<WhisperXResult> TranscribeAsync(string audioPath, CancellationToken cancellationToken)
+    {
+        if (!File.Exists(audioPath))
+        {
+            throw new FileNotFoundException("Audio file not found", audioPath);
+        }
+
+        var outputDir = PrepareOutputDirectory();
+        var psi = new ProcessStartInfo
+        {
+            FileName = _options.ExecutablePath,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        psi.ArgumentList.Add(audioPath);
+        psi.ArgumentList.Add("--model");
+        psi.ArgumentList.Add(_options.Model);
+        psi.ArgumentList.Add("--output_dir");
+        psi.ArgumentList.Add(outputDir);
+        psi.ArgumentList.Add("--output_format");
+        psi.ArgumentList.Add("json");
+        psi.ArgumentList.Add("--compute_type");
+        psi.ArgumentList.Add(_options.ComputeType);
+
+        if (_options.EnableDiarization)
+        {
+            psi.ArgumentList.Add("--diarize");
+        }
+
+        if (!string.IsNullOrWhiteSpace(_options.Language))
+        {
+            psi.ArgumentList.Add("--language");
+            psi.ArgumentList.Add(_options.Language!);
+        }
+
+        using var process = Process.Start(psi) ?? throw new InvalidOperationException("Failed to start whisperx process");
+
+        var stdoutTask = process.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
+
+        await WaitForExitAsync(process, cancellationToken).ConfigureAwait(false);
+
+        var stdout = await stdoutTask.ConfigureAwait(false);
+        var stderr = await stderrTask.ConfigureAwait(false);
+
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException($"WhisperX exited with code {process.ExitCode}: {stderr}\n{stdout}");
+        }
+
+        var resultFile = Directory.EnumerateFiles(outputDir, "*.json").FirstOrDefault();
+        if (resultFile is null)
+        {
+            throw new FileNotFoundException("WhisperX did not produce a JSON transcription file", outputDir);
+        }
+
+        await using var stream = File.OpenRead(resultFile);
+        using var document = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken).ConfigureAwait(false);
+        var segments = ParseSegments(document.RootElement);
+        CleanupOutputDirectory(outputDir);
+        return new WhisperXResult(segments);
+    }
+
+    private static async Task WaitForExitAsync(Process process, CancellationToken cancellationToken)
+    {
+        await Task.Run(() => process.WaitForExit(), cancellationToken).ConfigureAwait(false);
+    }
+
+    private static IReadOnlyList<TranscriptionSegment> ParseSegments(JsonElement root)
+    {
+        if (root.TryGetProperty("segments", out var segmentsElement) && segmentsElement.ValueKind == JsonValueKind.Array)
+        {
+            var segments = new List<TranscriptionSegment>();
+            foreach (var element in segmentsElement.EnumerateArray())
+            {
+                var speaker = element.TryGetProperty("speaker", out var speakerElement) ? speakerElement.GetString() ?? "Speaker" : "Speaker";
+                var text = element.TryGetProperty("text", out var textElement) ? textElement.GetString() ?? string.Empty : string.Empty;
+                var start = element.TryGetProperty("start", out var startElement) ? startElement.GetDouble() : 0d;
+                var end = element.TryGetProperty("end", out var endElement) ? endElement.GetDouble() : start;
+
+                segments.Add(new TranscriptionSegment(speaker, start, end, text.Trim()));
+            }
+
+            return segments;
+        }
+
+        throw new InvalidOperationException("WhisperX JSON output does not contain a 'segments' array.");
+    }
+
+    private string PrepareOutputDirectory()
+    {
+        if (!string.IsNullOrWhiteSpace(_options.OutputDirectory))
+        {
+            Directory.CreateDirectory(_options.OutputDirectory);
+            return _options.OutputDirectory;
+        }
+
+        var tempDir = Path.Combine(Path.GetTempPath(), "WhisperXOllamaApp", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        return tempDir;
+    }
+
+    private static void CleanupOutputDirectory(string directory)
+    {
+        try
+        {
+            if (Directory.Exists(directory) && directory.Contains("WhisperXOllamaApp", StringComparison.OrdinalIgnoreCase))
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+        }
+        catch
+        {
+            // Ignore cleanup failures.
+        }
+    }
+}

--- a/src/WhisperXOllamaApp/Utilities/TranscriptChunker.cs
+++ b/src/WhisperXOllamaApp/Utilities/TranscriptChunker.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using WhisperXOllamaApp.Models;
+
+namespace WhisperXOllamaApp.Utilities;
+
+public static class TranscriptChunker
+{
+    public static IReadOnlyList<TranscriptChunk> ChunkByWordCount(IEnumerable<TranscriptionSegment> segments, int maxWords)
+    {
+        if (maxWords <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxWords), "Chunk size must be greater than zero.");
+        }
+
+        var chunkList = new List<TranscriptChunk>();
+        var buffer = new StringBuilder();
+        var wordCount = 0;
+        TranscriptionSegment? firstSegment = null;
+        TranscriptionSegment? lastSegment = null;
+
+        void CommitChunk()
+        {
+            if (buffer.Length == 0 || firstSegment is null || lastSegment is null)
+            {
+                return;
+            }
+
+            var header = $"{FormatTimestamp(firstSegment.Start)} - {FormatTimestamp(lastSegment.End)} ({firstSegment.Speaker})";
+            chunkList.Add(new TranscriptChunk
+            {
+                Header = header,
+                Content = buffer.ToString().Trim(),
+                Start = TimeSpan.FromSeconds(firstSegment.Start),
+                End = TimeSpan.FromSeconds(lastSegment.End),
+            });
+
+            buffer.Clear();
+            wordCount = 0;
+            firstSegment = null;
+            lastSegment = null;
+        }
+
+        foreach (var segment in segments)
+        {
+            var words = segment.Text.Split(new[] { ' ', '\n', '\r', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+            if (wordCount + words.Length > maxWords && buffer.Length > 0)
+            {
+                CommitChunk();
+            }
+
+            if (firstSegment is null)
+            {
+                firstSegment = segment;
+            }
+
+            lastSegment = segment;
+            if (buffer.Length > 0)
+            {
+                buffer.AppendLine();
+            }
+
+            buffer.Append($"[{FormatTimestamp(segment.Start)} - {FormatTimestamp(segment.End)}] {segment.Speaker}: {segment.Text.Trim()}");
+            wordCount += words.Length;
+        }
+
+        CommitChunk();
+        return chunkList;
+    }
+
+    private static string FormatTimestamp(double seconds)
+    {
+        var ts = TimeSpan.FromSeconds(seconds);
+        return ts.ToString(ts.TotalHours >= 1 ? "hh\:mm\:ss" : "mm\:ss", CultureInfo.InvariantCulture);
+    }
+}

--- a/src/WhisperXOllamaApp/ViewModels/MainViewModel.cs
+++ b/src/WhisperXOllamaApp/ViewModels/MainViewModel.cs
@@ -1,0 +1,299 @@
+using System;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.Win32;
+using WhisperXOllamaApp.Models;
+using WhisperXOllamaApp.Services;
+using WhisperXOllamaApp.Utilities;
+
+namespace WhisperXOllamaApp.ViewModels;
+
+public partial class MainViewModel : ObservableObject
+{
+    private readonly WhisperXService _whisperXService;
+    private readonly OllamaService _ollamaService;
+    private readonly PromptPresetStorage _presetStorage;
+    private CancellationTokenSource? _processingCts;
+
+    [ObservableProperty]
+    private string _audioFilePath = string.Empty;
+
+    [ObservableProperty]
+    private ObservableCollection<string> _availableModels = new();
+
+    [ObservableProperty]
+    private string? _selectedModel;
+
+    [ObservableProperty]
+    private string _promptText = DefaultPrompt;
+
+    [ObservableProperty]
+    private ObservableCollection<PromptPreset> _promptPresets = new();
+
+    [ObservableProperty]
+    private PromptPreset? _selectedPreset;
+
+    [ObservableProperty]
+    private string _presetName = string.Empty;
+
+    [ObservableProperty]
+    private ObservableCollection<TranscriptChunk> _transcriptChunks = new();
+
+    [ObservableProperty]
+    private string _summaryText = string.Empty;
+
+    [ObservableProperty]
+    private string _transcriptionStatus = "Waiting for input.";
+
+    [ObservableProperty]
+    private bool _isProcessing;
+
+    [ObservableProperty]
+    private int _chunkSize = 1200;
+
+    public IRelayCommand BrowseAudioCommand { get; }
+    public IAsyncRelayCommand RefreshModelsCommand { get; }
+    public IAsyncRelayCommand GenerateSummaryCommand { get; }
+    public IAsyncRelayCommand SavePresetCommand { get; }
+    public IRelayCommand LoadPresetCommand { get; }
+    public IRelayCommand DeletePresetCommand { get; }
+
+    private static string DefaultPrompt => """You are an expert meeting summarizer.\n""" +
+        """Use the transcript chunk below to update the ongoing summary of the meeting.\n""" +
+        """Current summary so far (may be empty):\n{{previous_summary}}\n\n""" +
+        """Transcript chunk:\n{{chunk}}\n\n""" +
+        """Provide an updated concise summary that: \n""" +
+        """- Lists key decisions\n""" +
+        """- Highlights action items with owners and due dates if present\n""" +
+        """- Captures open questions\n\n""" +
+        """Return only the updated summary text.""";
+
+    public MainViewModel()
+        : this(new WhisperXService(), new OllamaService(), new PromptPresetStorage())
+    {
+    }
+
+    public MainViewModel(WhisperXService whisperXService, OllamaService ollamaService, PromptPresetStorage presetStorage)
+    {
+        _whisperXService = whisperXService;
+        _ollamaService = ollamaService;
+        _presetStorage = presetStorage;
+
+        BrowseAudioCommand = new RelayCommand(BrowseAudioFile);
+        RefreshModelsCommand = new AsyncRelayCommand(RefreshModelsAsync, () => !IsProcessing);
+        GenerateSummaryCommand = new AsyncRelayCommand(GenerateSummaryAsync, () => !IsProcessing);
+        SavePresetCommand = new AsyncRelayCommand(SavePresetAsync, () => !IsProcessing);
+        LoadPresetCommand = new RelayCommand(LoadSelectedPreset, () => SelectedPreset is not null);
+        DeletePresetCommand = new RelayCommand(DeleteSelectedPreset, () => SelectedPreset is not null && !IsProcessing);
+    }
+
+    partial void OnIsProcessingChanged(bool value)
+    {
+        RefreshModelsCommand.NotifyCanExecuteChanged();
+        GenerateSummaryCommand.NotifyCanExecuteChanged();
+        SavePresetCommand.NotifyCanExecuteChanged();
+        (DeletePresetCommand as RelayCommand)?.NotifyCanExecuteChanged();
+    }
+
+    partial void OnSelectedPresetChanged(PromptPreset? value)
+    {
+        (LoadPresetCommand as RelayCommand)?.NotifyCanExecuteChanged();
+        (DeletePresetCommand as RelayCommand)?.NotifyCanExecuteChanged();
+    }
+
+    partial void OnChunkSizeChanged(int value)
+    {
+        if (value <= 0)
+        {
+            ChunkSize = 1;
+        }
+    }
+
+    public async void InitializeAsync()
+    {
+        try
+        {
+            await LoadPresetsAsync();
+            await RefreshModelsAsync();
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Failed to initialize: {ex.Message}", "Initialization Error", MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+    }
+
+    private void BrowseAudioFile()
+    {
+        var dialog = new OpenFileDialog
+        {
+            Filter = "Audio Files|*.wav;*.mp3;*.m4a;*.flac;*.ogg|All Files|*.*"
+        };
+
+        if (dialog.ShowDialog() == true)
+        {
+            AudioFilePath = dialog.FileName;
+        }
+    }
+
+    private async Task RefreshModelsAsync()
+    {
+        try
+        {
+            IsProcessing = true;
+            TranscriptionStatus = "Loading Ollama models...";
+            var models = await _ollamaService.ListModelsAsync(CancellationToken.None);
+            Application.Current.Dispatcher.Invoke(() =>
+            {
+                AvailableModels = new ObservableCollection<string>(models);
+                if (!models.Contains(SelectedModel))
+                {
+                    SelectedModel = models.FirstOrDefault();
+                }
+            });
+            TranscriptionStatus = models.Count > 0 ? "Models loaded." : "No models available.";
+        }
+        catch (Exception ex)
+        {
+            TranscriptionStatus = $"Failed to load models: {ex.Message}";
+        }
+        finally
+        {
+            IsProcessing = false;
+        }
+    }
+
+    private async Task GenerateSummaryAsync()
+    {
+        if (string.IsNullOrWhiteSpace(AudioFilePath) || !File.Exists(AudioFilePath))
+        {
+            MessageBox.Show("Please select a valid audio file.", "Missing Audio", MessageBoxButton.OK, MessageBoxImage.Warning);
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(SelectedModel))
+        {
+            MessageBox.Show("Please choose an Ollama model.", "Missing Model", MessageBoxButton.OK, MessageBoxImage.Warning);
+            return;
+        }
+
+        _processingCts?.Cancel();
+        _processingCts = new CancellationTokenSource();
+        var cancellationToken = _processingCts.Token;
+
+        try
+        {
+            IsProcessing = true;
+            TranscriptionStatus = "Running WhisperX transcription...";
+            var transcription = await _whisperXService.TranscribeAsync(AudioFilePath, cancellationToken);
+            var chunks = TranscriptChunker.ChunkByWordCount(transcription.Segments, ChunkSize);
+            Application.Current.Dispatcher.Invoke(() =>
+            {
+                TranscriptChunks = new ObservableCollection<TranscriptChunk>(chunks);
+            });
+            TranscriptionStatus = $"Transcription completed with {chunks.Count} chunk(s).";
+
+            var previousSummary = string.Empty;
+            var chunkIndex = 1;
+            foreach (var chunk in chunks)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                TranscriptionStatus = $"Summarizing chunk {chunkIndex} of {chunks.Count}...";
+                var prompt = BuildPromptForChunk(chunk.Content, previousSummary);
+                var response = await _ollamaService.GenerateResponseAsync(SelectedModel!, prompt, cancellationToken);
+                previousSummary = response.Trim();
+                chunkIndex++;
+            }
+
+            SummaryText = previousSummary;
+            TranscriptionStatus = "Summary generation complete.";
+        }
+        catch (OperationCanceledException)
+        {
+            TranscriptionStatus = "Processing cancelled.";
+        }
+        catch (Exception ex)
+        {
+            TranscriptionStatus = $"Failed: {ex.Message}";
+            MessageBox.Show(ex.Message, "Processing Error", MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+        finally
+        {
+            IsProcessing = false;
+        }
+    }
+
+    private string BuildPromptForChunk(string chunkContent, string previousSummary)
+    {
+        return PromptText
+            .Replace("{{chunk}}", chunkContent)
+            .Replace("{{previous_summary}}", string.IsNullOrWhiteSpace(previousSummary) ? "(none)" : previousSummary);
+    }
+
+    private async Task SavePresetAsync()
+    {
+        if (string.IsNullOrWhiteSpace(PresetName))
+        {
+            MessageBox.Show("Enter a name for the preset.", "Preset Name Required", MessageBoxButton.OK, MessageBoxImage.Information);
+            return;
+        }
+
+        var existing = PromptPresets.FirstOrDefault(p => string.Equals(p.Name, PresetName, StringComparison.OrdinalIgnoreCase));
+        if (existing is null)
+        {
+            existing = new PromptPreset { Name = PresetName };
+            PromptPresets.Add(existing);
+        }
+
+        existing.Prompt = PromptText;
+        await _presetStorage.SaveAsync(PromptPresets);
+        MessageBox.Show($"Preset '{PresetName}' saved.", "Preset Saved", MessageBoxButton.OK, MessageBoxImage.Information);
+    }
+
+    private async Task LoadPresetsAsync()
+    {
+        try
+        {
+            var presets = await _presetStorage.LoadAsync();
+            Application.Current.Dispatcher.Invoke(() =>
+            {
+                PromptPresets = new ObservableCollection<PromptPreset>(presets);
+            });
+        }
+        catch (Exception ex)
+        {
+            TranscriptionStatus = $"Failed to load presets: {ex.Message}";
+        }
+    }
+
+    private void LoadSelectedPreset()
+    {
+        if (SelectedPreset is null)
+        {
+            return;
+        }
+
+        PromptText = SelectedPreset.Prompt;
+        PresetName = SelectedPreset.Name;
+    }
+
+    private async void DeleteSelectedPreset()
+    {
+        if (SelectedPreset is null)
+        {
+            return;
+        }
+
+        if (MessageBox.Show($"Delete preset '{SelectedPreset.Name}'?", "Delete Preset", MessageBoxButton.YesNo, MessageBoxImage.Question) == MessageBoxResult.Yes)
+        {
+            PromptPresets.Remove(SelectedPreset);
+            await _presetStorage.SaveAsync(PromptPresets);
+            SelectedPreset = null;
+        }
+    }
+}

--- a/src/WhisperXOllamaApp/Views/MainWindow.xaml
+++ b/src/WhisperXOllamaApp/Views/MainWindow.xaml
@@ -1,0 +1,120 @@
+<Window x:Class="WhisperXOllamaApp.Views.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:vm="clr-namespace:WhisperXOllamaApp.ViewModels"
+        mc:Ignorable="d"
+        Title="WhisperX Ollama Meeting Summarizer"
+        Height="720"
+        Width="1100">
+    <Window.DataContext>
+        <vm:MainViewModel />
+    </Window.DataContext>
+
+    <Grid Margin="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="2*" />
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+
+        <GroupBox Header="Audio Source" Grid.Row="0" Grid.ColumnSpan="2" Margin="0 0 0 12">
+            <Grid Margin="8">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <TextBox Text="{Binding AudioFilePath, UpdateSourceTrigger=PropertyChanged}" Margin="0 0 8 0"/>
+                <Button Content="Browse" Grid.Column="1" Command="{Binding BrowseAudioCommand}" Width="100"/>
+            </Grid>
+        </GroupBox>
+
+        <GroupBox Header="Ollama Configuration" Grid.Row="1" Grid.Column="0" Margin="0 0 12 12">
+            <StackPanel Margin="8">
+                <StackPanel Orientation="Horizontal" Margin="0 0 0 8">
+                    <TextBlock Text="Model" VerticalAlignment="Center" Width="80"/>
+                    <ComboBox ItemsSource="{Binding AvailableModels}"
+                              SelectedItem="{Binding SelectedModel}"
+                              Width="200"/>
+                    <Button Content="Refresh" Width="90" Command="{Binding RefreshModelsCommand}" Margin="8 0 0 0"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="0 0 0 8">
+                    <TextBlock Text="Chunk Size (words)" VerticalAlignment="Center" Width="140"/>
+                    <TextBox Text="{Binding ChunkSize, UpdateSourceTrigger=PropertyChanged}" Width="80"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Text="Preset" VerticalAlignment="Center" Width="80"/>
+                    <ComboBox ItemsSource="{Binding PromptPresets}" SelectedItem="{Binding SelectedPreset}" DisplayMemberPath="Name" Width="200"/>
+                    <Button Content="Load" Command="{Binding LoadPresetCommand}" Width="70" Margin="8 0 0 0"/>
+                    <Button Content="Save" Command="{Binding SavePresetCommand}" Width="70" Margin="8 0 0 0"/>
+                    <Button Content="Delete" Command="{Binding DeletePresetCommand}" Width="80" Margin="8 0 0 0"/>
+                </StackPanel>
+            </StackPanel>
+        </GroupBox>
+
+        <GroupBox Header="Prompt" Grid.Row="1" Grid.Column="1" Margin="0 0 0 12">
+            <Grid Margin="8">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+                <TextBox Text="{Binding PromptText, UpdateSourceTrigger=PropertyChanged}"
+                         AcceptsReturn="True"
+                         VerticalScrollBarVisibility="Auto"
+                         TextWrapping="Wrap"/>
+                <TextBox Grid.Row="1"
+                         Margin="0 8 0 0"
+                         ToolTip="Name for saving the current prompt as a preset"
+                         Text="{Binding PresetName, UpdateSourceTrigger=PropertyChanged}"/>
+            </Grid>
+        </GroupBox>
+
+        <GroupBox Header="Transcription" Grid.Row="2" Grid.ColumnSpan="2" Margin="0 0 0 12">
+            <Grid Margin="8">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+                <TextBlock Text="{Binding TranscriptionStatus}" Margin="0 0 0 8"/>
+                <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
+                    <ItemsControl ItemsSource="{Binding TranscriptChunks}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Border BorderBrush="Gray" BorderThickness="1" Margin="0 0 0 8" Padding="8">
+                                    <StackPanel>
+                                        <TextBlock Text="{Binding Header}" FontWeight="Bold"/>
+                                        <TextBlock Text="{Binding Content}" TextWrapping="Wrap" Margin="0 4 0 0"/>
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </ScrollViewer>
+            </Grid>
+        </GroupBox>
+
+        <GroupBox Header="Summary" Grid.Row="3" Grid.ColumnSpan="2">
+            <Grid Margin="8">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+                <StackPanel Orientation="Horizontal" Margin="0 0 0 8">
+                    <Button Content="Generate Summary" Command="{Binding GenerateSummaryCommand}" Width="160"/>
+                    <ProgressBar Width="200" Height="20" IsIndeterminate="{Binding IsProcessing}" Visibility="{Binding IsProcessing, Converter={StaticResource BooleanToVisibilityConverter}}" Margin="8 0 0 0"/>
+                </StackPanel>
+                <TextBox Grid.Row="1"
+                         Text="{Binding SummaryText}"
+                         AcceptsReturn="True"
+                         TextWrapping="Wrap"
+                         VerticalScrollBarVisibility="Auto"/>
+            </Grid>
+        </GroupBox>
+    </Grid>
+</Window>

--- a/src/WhisperXOllamaApp/Views/MainWindow.xaml.cs
+++ b/src/WhisperXOllamaApp/Views/MainWindow.xaml.cs
@@ -1,0 +1,16 @@
+using System.Windows;
+using WhisperXOllamaApp.ViewModels;
+
+namespace WhisperXOllamaApp.Views;
+
+public partial class MainWindow : Window
+{
+    public MainWindow()
+    {
+        InitializeComponent();
+        if (DataContext is MainViewModel vm)
+        {
+            vm.InitializeAsync();
+        }
+    }
+}

--- a/src/WhisperXOllamaApp/WhisperXOllamaApp.csproj
+++ b/src/WhisperXOllamaApp/WhisperXOllamaApp.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add a new .NET 8 WPF application that orchestrates WhisperX diarized transcription and Ollama summarisation
- implement services for running the whisperx and ollama CLI tools, transcript chunking, and prompt preset persistence
- build a GUI with model selection, prompt editing, preset management, transcript chunk display, and iterative summary generation

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dbc7224c9c8327a54db6fd37ff4de0